### PR TITLE
Add Stop button to audio playback

### DIFF
--- a/root/code/frontend/review_detections.py
+++ b/root/code/frontend/review_detections.py
@@ -194,6 +194,7 @@ class ReviewDetectionsScreen(QMainWindow):
         self.player = QMediaPlayer(self)
         self.audio_output = QAudioOutput(self)
         self.player.setAudioOutput(self.audio_output)
+        self.player.playbackStateChanged.connect(self.on_playback_state_changed)
 
         # Create spinboxes + labels for adjusting start/end
         self.start_label = QLabel("Start time:")
@@ -210,6 +211,10 @@ class ReviewDetectionsScreen(QMainWindow):
         self.play_button.setToolTip("Shift + Space")
         self.play_button.clicked.connect(self.play_selected_segment)
 
+        self.stop_button = QPushButton("Stop")
+        self.stop_button.setEnabled(False)
+        self.stop_button.clicked.connect(self.stop_audio_playback)
+
         # Audio controls layout (two rows)
         self.audio_vlayout = QVBoxLayout()
         # 1) First row: Start time, End time
@@ -221,11 +226,13 @@ class ReviewDetectionsScreen(QMainWindow):
         # add to vertical layout
         self.audio_vlayout.addLayout(self.audio_hlayout)
 
-        # 2) Second row: Play button
+        # 2) Second row: Play / Stop buttons
         self.play_button.setFixedWidth(80)  # optional sizing
+        self.stop_button.setFixedWidth(80)
         self.play_button_hbox = QHBoxLayout()
-        self.play_button_hbox.addWidget(self.play_button) 
-        self.play_button_hbox.addStretch()  # push the button left, or remove if you like center
+        self.play_button_hbox.addWidget(self.play_button)
+        self.play_button_hbox.addWidget(self.stop_button)
+        self.play_button_hbox.addStretch()  # push the buttons left, or remove if you like center
         self.audio_vlayout.addLayout(self.play_button_hbox)
 
         # Now we have self.audio_vlayout containing:
@@ -320,6 +327,15 @@ class ReviewDetectionsScreen(QMainWindow):
 
         # 7) Start playback
         self.player.play()
+        self.stop_button.setEnabled(True)
+
+    def stop_audio_playback(self):
+        self.player.stop()
+        self.stop_button.setEnabled(False)
+
+    def on_playback_state_changed(self, state):
+        if state != QMediaPlayer.PlayingState:
+            self.stop_button.setEnabled(False)
 
     def apply_keep(self):
         self.apply_label_to_current_detection(erase_flag=0)


### PR DESCRIPTION
## Summary
- add a Stop button next to Play in the review UI
- hook up playback state signal to enable/disable Stop

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6886d6a8c9e083218c67217d26af0a17